### PR TITLE
Memcached service will now be enabled by default.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,8 @@ class memcached(
   }
 
   class { 'memcached::service':
-    require => Class['memcached::config'],
+    enable_memcached => $enable_memcached,
+    require          => Class['memcached::config'],
   }
 
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,8 +1,14 @@
 # == Class: memcached::service
-class memcached::service {
+class memcached::service ( $enable_memcached = 'yes' ) {
+
+  case $enable_memcached {
+    'no'   : { $enable = false }
+    default: { $enable = true }
+  }
 
   service { 'memcached':
     ensure => running,
+    enable => $enable,
   }
 
 }

--- a/spec/acceptance/memcached_spec.rb
+++ b/spec/acceptance/memcached_spec.rb
@@ -21,4 +21,9 @@ describe 'memcached class' do
       expect(shell("memcached -h").exit_code).to eql(0)
     end
   end
+
+  describe service('memcached') do
+    it { should be_running  }
+    it { should be_enabled  }
+  end
 end

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -1,5 +1,8 @@
 require 'spec_helper'
 
 describe 'memcached::service' do
-  it { should contain_service('memcached') }
+  it { should contain_service('memcached').with({
+      'enable' => true,
+    }) 
+  }
 end


### PR DESCRIPTION
The current module installs memcached and ensures that puppet will start it eventually, but it is not configured to start at boot. This change will make memcached start at boot by default. This is useful for folks who are using headless puppet and may expect memcached to be usable immediately.

The feature is controlled by the existing $enable_memcached setting. 
